### PR TITLE
Fix the Migration timestamp error when zero

### DIFF
--- a/src/devtool/src/Annotation/Parser/MigrationParser.php
+++ b/src/devtool/src/Annotation/Parser/MigrationParser.php
@@ -37,7 +37,7 @@ class MigrationParser extends Parser
         $migrationName = StringHelper::replaceLast((string)$time, '', $className);
         $time          = (int)$time;
 
-        if (empty($time)) {
+        if (empty($time) && $time !== 0) {
             throw new InvalidArgumentException(get_class($annotationObject) . ' time params must exists');
         }
 


### PR DESCRIPTION
Before that time, I've created a migration class. I don't want to specify the timestamp, because the timestamp is useless to the current of me. When I set the timestamp with zero the InvalidArgumentException occurred... otherwise, I've looked over the definition of Migration annotation, the parameter $time with a default value is zero, so, I guess this is a bug